### PR TITLE
Link

### DIFF
--- a/Examples/Link/main.swift
+++ b/Examples/Link/main.swift
@@ -1,6 +1,6 @@
 import AnsiEscapes
 
 print(clearTerminal())
-print(printLink(withText: "Repository", andUrl: "https://github.com/ikelax/swift-ansi-escapes"))
-print(printLink(withText: "Open Users folder (works on macOS and Windows)", andUrl: "file:///Users"))
-print(printLink(withText: "Open home folder (works on macOS and Linux)", andUrl: "file:///home"))
+print(link(withText: "Repository", andUrl: "https://github.com/ikelax/swift-ansi-escapes"))
+print(link(withText: "Open Users folder (works on macOS and Windows)", andUrl: "file:///Users"))
+print(link(withText: "Open home folder (works on macOS and Linux)", andUrl: "file:///home"))

--- a/Sources/AnsiEscapes.swift
+++ b/Sources/AnsiEscapes.swift
@@ -129,7 +129,14 @@ public func eraseLines(count: Int) -> String {
   return escapeCode
 }
 
-public func printLink(withText text: String, andUrl url: String) -> String {
+/// Creates a clickable link. For supported terminals see
+/// [1](https://emnudge.dev/notes/terminal-links/) and
+/// [2](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda).
+/// - Parameters:
+///   - text: The text of the link
+///   - url: The URL of the link
+/// - Returns: The ANSI escape code.
+public func link(withText text: String, andUrl url: String) -> String {
   [
     ANSIEscapeCode.OSC,
     "8",

--- a/Tests/Link.swift
+++ b/Tests/Link.swift
@@ -1,0 +1,9 @@
+import Testing
+import AnsiEscapes
+
+@Test("Creates a clickable link") func createsClickableLink() {
+  #expect(
+    link(withText: "Link", andUrl: "https://github.com/ikelax/swift-ansi-escapes")
+    == "\u{001B}]8;;https://github.com/ikelax/swift-ansi-escapes\u{0007}Link\u{001B}]8;;\u{0007}"
+  )
+}


### PR DESCRIPTION
I added tests and comments for `link` and renamed `printLink` to `link` because it is more consistent with the names of other functions.