### PR TITLE
Namespace, setCurrentDir and annotations in iTerm2

### DIFF
--- a/Examples/iTermAnnotation/main.swift
+++ b/Examples/iTermAnnotation/main.swift
@@ -2,4 +2,23 @@ import AnsiEscapes
 
 print(ANSIEscapeCode.clearTerminal())
 
-print(annotationiTerm(message: "Hello, world!", options: try! iTermAnnotationOptions(x: 0, y: 0, length: 0, isHidden: false)))
+print("Hi!", terminator: "")
+print(ANSIEscapeCode.iTerm.annotation(message: "Hi, back!", options: try! iTermAnnotationOptions(x: 0, y: 1, length: 3)))
+
+print("")
+print("")
+
+print("Wǎn shàng hǎo", terminator: "")
+print(ANSIEscapeCode.iTerm.annotation(message: "Wǎn shàng hǎo", options: try! iTermAnnotationOptions(length: 1)))
+
+print("")
+print("")
+
+print("こんにちは", terminator: "")
+print(ANSIEscapeCode.iTerm.annotation(message: "こんにちは", options: try! iTermAnnotationOptions()))
+
+print("")
+print("")
+
+print("To see the hidden annotation: Right click > Reveal Annotation.", terminator: "")
+print(ANSIEscapeCode.iTerm.annotation(message: "Now, you see it :)", options: try! iTermAnnotationOptions(isHidden: true)))

--- a/Sources/AnsiEscapes.swift
+++ b/Sources/AnsiEscapes.swift
@@ -161,33 +161,6 @@ public struct ImageOptions {
   let preverseAspectRatio: Bool
 }
 
-public func printImage(data: String, options: ImageOptions?) -> String {
-  var escapeCodePrefix = "\(ANSIEscapeCode.OSC)1337;File=inline=1"
-  let escapeCodeForImage = ":\(ANSIEscapeCode.BEL)"
-  
-  guard let options = options else {
-    return escapeCodePrefix + escapeCodeForImage
-  }
-  
-  if options.width != 0 {
-    escapeCodePrefix += ";width=\(options.width)"
-  }
-  
-  if options.height != 0 {
-    escapeCodePrefix += ";height=\(options.height)"
-  }
-  
-  if !options.preverseAspectRatio {
-    escapeCodePrefix += ";preserveAspectRatio=0"
-  }
-  
-  return escapeCodePrefix + escapeCodeForImage
-}
-
-public func setCwdiTerm(cwd: String) -> String {
-  "\(ANSIEscapeCode.OSC)50;CurrentDir=\(cwd)\(ANSIEscapeCode.BEL)"
-}
-
 public struct iTermAnnotationOptions {
   let length: Int?
   let x: Int?
@@ -213,24 +186,4 @@ public struct iTermAnnotationOptions {
     self.y = y
     self.isHidden = isHidden
   }
-}
-
-public func annotationiTerm(message: String, options: iTermAnnotationOptions) -> String {
-  let hiddenEscapeCode = options.isHidden ? "AddHiddenAnnotation=" : "AddAnnotation="
-  var escapeCode = "\(ANSIEscapeCode.OSC)1337;\(hiddenEscapeCode)"
-  
-  var message = message
-  message.replace("|", with: "")
-  
-  if options.length != 0 {
-    if options.hasX() {
-      escapeCode += "\(message)|\(options.length!)|\(options.x!)|\(options.y!)"
-    } else {
-      escapeCode += "\(options.length!)|\(message)"
-    }
-  } else {
-    escapeCode += message
-  }
-  
-  return escapeCode + ANSIEscapeCode.BEL
 }

--- a/Sources/AnsiEscapes.swift
+++ b/Sources/AnsiEscapes.swift
@@ -160,30 +160,3 @@ public struct ImageOptions {
   let width: Int
   let preverseAspectRatio: Bool
 }
-
-public struct iTermAnnotationOptions {
-  let length: Int?
-  let x: Int?
-  let y: Int?
-  let isHidden: Bool
-  
-  enum AnnotationError: Error {
-    case invalidOptions(String)
-  }
-  
-  public func hasX() -> Bool { x != nil }
-  
-  public init(x: Int? = nil, y: Int? = nil, length: Int? = nil, isHidden: Bool = false) throws {
-    let hasX = x != nil
-    let hasY = y != nil
-    
-    if (hasX || hasY) && !(hasX && hasY && length != nil) {
-      throw AnnotationError.invalidOptions("`x`, `y` and `length` must be defined when `x` or `y` is defined")
-    }
-    
-    self.length = length
-    self.x = x
-    self.y = y
-    self.isHidden = isHidden
-  }
-}

--- a/Sources/iTerm.swift
+++ b/Sources/iTerm.swift
@@ -12,18 +12,18 @@ extension ANSIEscapeCode {
       "\(ANSIEscapeCode.OSC)1337;CurrentDir=\(dir)\(ANSIEscapeCode.BEL)"
     }
     
-    public func annotation(message: String, options: iTermAnnotationOptions) -> String {
+    public static func annotation(message: String, options: iTermAnnotationOptions) -> String {
       let hiddenEscapeCode = options.isHidden ? "AddHiddenAnnotation=" : "AddAnnotation="
       var escapeCode = "\(ANSIEscapeCode.OSC)1337;\(hiddenEscapeCode)"
       
       var message = message
       message.replace("|", with: "")
       
-      if options.length != 0 {
+      if let length = options.length {
         if options.hasX() {
-          escapeCode += "\(message)|\(options.length!)|\(options.x!)|\(options.y!)"
+          escapeCode += "\(message)|\(length)|\(options.x!)|\(options.y!)"
         } else {
-          escapeCode += "\(options.length!)|\(message)"
+          escapeCode += "\(length)|\(message)"
         }
       } else {
         escapeCode += message

--- a/Sources/iTerm.swift
+++ b/Sources/iTerm.swift
@@ -2,6 +2,9 @@ extension ANSIEscapeCode {
   public struct iTerm {
     private init() {}
     
+    /// Inform iTerm2 of the current directory to help semantic history.
+    /// - Parameter dir: The current directory to inform to iTerm2.
+    /// - Returns: The ANSI escape code.
     public static func informCurrentDir(_ dir: String) -> String {
       "\(ANSIEscapeCode.OSC)1337;CurrentDir=\(dir)\(ANSIEscapeCode.BEL)"
     }

--- a/Sources/iTerm.swift
+++ b/Sources/iTerm.swift
@@ -8,7 +8,7 @@ extension ANSIEscapeCode {
     /// Inform iTerm2 of the current directory to help semantic history.
     /// - Parameter dir: The current directory to inform to iTerm2.
     /// - Returns: The proprietary escape code supported by iTerm2.
-    public static func informCurrentDir(_ dir: String) -> String {
+    public static func setCurrentDir(_ dir: String) -> String {
       "\(ANSIEscapeCode.OSC)1337;CurrentDir=\(dir)\(ANSIEscapeCode.BEL)"
     }
     

--- a/Sources/iTerm.swift
+++ b/Sources/iTerm.swift
@@ -1,0 +1,53 @@
+extension ANSIEscapeCode {
+  public struct iTerm {
+    private init() {}
+    
+    public static func informCurrentDir(_ dir: String) -> String {
+      "\(ANSIEscapeCode.OSC)1337;CurrentDir=\(dir)\(ANSIEscapeCode.BEL)"
+    }
+    
+    public func annotation(message: String, options: iTermAnnotationOptions) -> String {
+      let hiddenEscapeCode = options.isHidden ? "AddHiddenAnnotation=" : "AddAnnotation="
+      var escapeCode = "\(ANSIEscapeCode.OSC)1337;\(hiddenEscapeCode)"
+      
+      var message = message
+      message.replace("|", with: "")
+      
+      if options.length != 0 {
+        if options.hasX() {
+          escapeCode += "\(message)|\(options.length!)|\(options.x!)|\(options.y!)"
+        } else {
+          escapeCode += "\(options.length!)|\(message)"
+        }
+      } else {
+        escapeCode += message
+      }
+      
+      return escapeCode + ANSIEscapeCode.BEL
+    }
+    
+    public func image(data: String, options: ImageOptions?) -> String {
+      var escapeCodePrefix = "\(ANSIEscapeCode.OSC)1337;File=inline=1"
+      let escapeCodeForImage = ":\(ANSIEscapeCode.BEL)"
+      
+      guard let options = options else {
+        return escapeCodePrefix + escapeCodeForImage
+      }
+      
+      if options.width != 0 {
+        escapeCodePrefix += ";width=\(options.width)"
+      }
+      
+      if options.height != 0 {
+        escapeCodePrefix += ";height=\(options.height)"
+      }
+      
+      if !options.preverseAspectRatio {
+        escapeCodePrefix += ";preserveAspectRatio=0"
+      }
+      
+      return escapeCodePrefix + escapeCodeForImage
+    }
+  }
+
+}

--- a/Sources/iTerm.swift
+++ b/Sources/iTerm.swift
@@ -1,4 +1,7 @@
 extension ANSIEscapeCode {
+  
+  /// iTerm supports proprietary escape codes. You can read more about them
+  /// in the [iTerm documentation](https://iterm2.com/documentation-escape-codes.html).
   public struct iTerm {
     private init() {}
     

--- a/Sources/iTerm.swift
+++ b/Sources/iTerm.swift
@@ -1,17 +1,22 @@
 extension ANSIEscapeCode {
   
-  /// iTerm supports proprietary escape codes. You can read more about them
-  /// in the [iTerm documentation](https://iterm2.com/documentation-escape-codes.html).
+  /// iTerm2 supports proprietary escape codes. You can read more about them
+  /// in the [iTerm2 documentation](https://iterm2.com/documentation-escape-codes.html).
   public struct iTerm {
     private init() {}
     
     /// Inform iTerm2 of the current directory to help semantic history.
     /// - Parameter dir: The current directory to inform to iTerm2.
-    /// - Returns: The ANSI escape code.
+    /// - Returns: The proprietary escape code supported by iTerm2.
     public static func informCurrentDir(_ dir: String) -> String {
       "\(ANSIEscapeCode.OSC)1337;CurrentDir=\(dir)\(ANSIEscapeCode.BEL)"
     }
     
+    /// Adds an annotation displayed in iTerm2.
+    /// - Parameters:
+    ///   - message: The message to attach to the annotation. The `|` character is disallowed and will be stripped.
+    ///   - options: Options for the annotation escape code. See also ``iTermAnnotationOptions``.
+    /// - Returns: The proprietary escape code supported by iTerm2.
     public static func annotation(message: String, options: iTermAnnotationOptions) -> String {
       let hiddenEscapeCode = options.isHidden ? "AddHiddenAnnotation=" : "AddAnnotation="
       var escapeCode = "\(ANSIEscapeCode.OSC)1337;\(hiddenEscapeCode)"

--- a/Sources/iTermAnnotationOptions.swift
+++ b/Sources/iTermAnnotationOptions.swift
@@ -13,7 +13,7 @@ public struct iTermAnnotationOptions {
   ///   - x: The starting x-coordinate for the annotation. Defaults to the cursor's x-coordinate.
   ///   - y: The starting y-coordinate for the annotation. Defaults to the cursor's y-coordinate.
   ///   - length: The number of cells to annotate. Defaults to the rest of the line beginning at the start of the annotation. `length` has to be positive.
-  ///   - isHidden: Hidden (`true`) does not reveal the annotation window at the time the escape sequence is received, while not hidden (`false`) opens it immediately.
+  ///   - isHidden: Controls whether to open the annotation windows immediately. The annotation can be revealed by the command `Reveal Annotation` in the context menu.
   public init(x: Int? = nil, y: Int? = nil, length: Int? = nil, isHidden: Bool = false) throws {
     let hasX = x != nil
     let hasY = y != nil

--- a/Sources/iTermAnnotationOptions.swift
+++ b/Sources/iTermAnnotationOptions.swift
@@ -1,3 +1,5 @@
+/// The options for the [annotation feature](https://iterm2.com/documentation-escape-codes.html) in iTerm.
+/// Scroll in the documentation to Annotations.
 public struct iTermAnnotationOptions {
   let length: Int?
   let x: Int?
@@ -6,6 +8,12 @@ public struct iTermAnnotationOptions {
   
   func hasX() -> Bool { x != nil }
   
+  /// `x`, `y` and `length` must be defined when `x` or `y` is defined.
+  /// - Parameters:
+  ///   - x: The starting x-coordinate for the annotation. Defaults to the cursor's x-coordinate.
+  ///   - y: The starting y-coordinate for the annotation. Defaults to the cursor's y-coordinate.
+  ///   - length: The number of cells to annotate. Defaults to the rest of the line beginning at the start of the annotation.
+  ///   - isHidden: Hidden (`true`) does not reveal the annotation window at the time the escape sequence is received, while not hidden (`false`) opens it immediately.
   public init(x: Int? = nil, y: Int? = nil, length: Int? = nil, isHidden: Bool = false) throws {
     let hasX = x != nil
     let hasY = y != nil
@@ -21,6 +29,7 @@ public struct iTermAnnotationOptions {
   }
 }
 
-enum iTermAnnotationError: Error {
+enum iTermAnnotationError: Error, Equatable {
+  /// This error is thrown when `x` or `y` were defined but at least one of `x`, `y` and `length` in ``iTermAnnotationOptions`` where `nil`.
   case invalidOptions(String)
 }

--- a/Sources/iTermAnnotationOptions.swift
+++ b/Sources/iTermAnnotationOptions.swift
@@ -1,0 +1,26 @@
+public struct iTermAnnotationOptions {
+  let length: Int?
+  let x: Int?
+  let y: Int?
+  let isHidden: Bool
+  
+  func hasX() -> Bool { x != nil }
+  
+  public init(x: Int? = nil, y: Int? = nil, length: Int? = nil, isHidden: Bool = false) throws {
+    let hasX = x != nil
+    let hasY = y != nil
+    
+    if (hasX || hasY) && !(hasX && hasY && length != nil) {
+      throw iTermAnnotationError.invalidOptions("`x`, `y` and `length` must be defined when `x` or `y` is defined")
+    }
+    
+    self.length = length
+    self.x = x
+    self.y = y
+    self.isHidden = isHidden
+  }
+}
+
+enum iTermAnnotationError: Error {
+  case invalidOptions(String)
+}

--- a/Sources/iTermAnnotationOptions.swift
+++ b/Sources/iTermAnnotationOptions.swift
@@ -1,6 +1,6 @@
 /// The options for the [annotation feature](https://iterm2.com/documentation-escape-codes.html) in iTerm2.
 /// Scroll in the documentation to Annotations.
-public struct iTermAnnotationOptions {
+public struct iTermAnnotationOptions: Sendable {
   let length: Int?
   let x: Int?
   let y: Int?

--- a/Sources/iTermAnnotationOptions.swift
+++ b/Sources/iTermAnnotationOptions.swift
@@ -1,4 +1,4 @@
-/// The options for the [annotation feature](https://iterm2.com/documentation-escape-codes.html) in iTerm.
+/// The options for the [annotation feature](https://iterm2.com/documentation-escape-codes.html) in iTerm2.
 /// Scroll in the documentation to Annotations.
 public struct iTermAnnotationOptions {
   let length: Int?
@@ -6,20 +6,26 @@ public struct iTermAnnotationOptions {
   let y: Int?
   let isHidden: Bool
   
-  func hasX() -> Bool { x != nil }
+  public func hasX() -> Bool { x != nil }
   
   /// `x`, `y` and `length` must be defined when `x` or `y` is defined.
   /// - Parameters:
   ///   - x: The starting x-coordinate for the annotation. Defaults to the cursor's x-coordinate.
   ///   - y: The starting y-coordinate for the annotation. Defaults to the cursor's y-coordinate.
-  ///   - length: The number of cells to annotate. Defaults to the rest of the line beginning at the start of the annotation.
+  ///   - length: The number of cells to annotate. Defaults to the rest of the line beginning at the start of the annotation. `length` has to be positive.
   ///   - isHidden: Hidden (`true`) does not reveal the annotation window at the time the escape sequence is received, while not hidden (`false`) opens it immediately.
   public init(x: Int? = nil, y: Int? = nil, length: Int? = nil, isHidden: Bool = false) throws {
     let hasX = x != nil
     let hasY = y != nil
     
+    if let length = length {
+      if length <= 0 {
+        throw iTermAnnotationError.invalidLength
+      }
+    }
+    
     if (hasX || hasY) && !(hasX && hasY && length != nil) {
-      throw iTermAnnotationError.invalidOptions("`x`, `y` and `length` must be defined when `x` or `y` is defined")
+      throw iTermAnnotationError.xOrYImpliesXYAndLength
     }
     
     self.length = length
@@ -30,6 +36,8 @@ public struct iTermAnnotationOptions {
 }
 
 enum iTermAnnotationError: Error, Equatable {
-  /// This error is thrown when `x` or `y` were defined but at least one of `x`, `y` and `length` in ``iTermAnnotationOptions`` where `nil`.
-  case invalidOptions(String)
+  /// `x`, `y` and `length` in ``iTermAnnotationOptions`` must be defined when `x` or `y` is defined'.
+  case xOrYImpliesXYAndLength
+  /// `length` in ``iTermAnnotationOptions`` must be positive. Otherwise, the annotation is not displayed.
+  case invalidLength
 }

--- a/Tests/iTerm/Annotation.swift
+++ b/Tests/iTerm/Annotation.swift
@@ -1,0 +1,37 @@
+import Testing
+import AnsiEscapes
+
+// | is disallowed and therefore stripped.
+let testCases = [
+  // isHidden: false
+  ("", try! iTermAnnotationOptions(), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=\(ANSIEscapeCode.BEL)"),
+  ("|", try! iTermAnnotationOptions(), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=\(ANSIEscapeCode.BEL)"),
+  ("Hello world!", try! iTermAnnotationOptions(), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=Hello world!\(ANSIEscapeCode.BEL)"),
+  ("Hello|'|world:", try! iTermAnnotationOptions(), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=Hello'world:\(ANSIEscapeCode.BEL)"),
+  
+  // isHidden: true
+  ("", try! iTermAnnotationOptions(isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=\(ANSIEscapeCode.BEL)"),
+  ("||||", try! iTermAnnotationOptions(isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=\(ANSIEscapeCode.BEL)"),
+  (".H.i,", try! iTermAnnotationOptions(isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=.H.i,\(ANSIEscapeCode.BEL)"),
+  (".H|i,", try! iTermAnnotationOptions(isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=.Hi,\(ANSIEscapeCode.BEL)"),
+  
+  // length: k, isHidden: false
+  ("", try! iTermAnnotationOptions(length: 10), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=10|\(ANSIEscapeCode.BEL)"),
+  ("||", try! iTermAnnotationOptions(length: 1), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=1|\(ANSIEscapeCode.BEL)"),
+  ("message", try! iTermAnnotationOptions(length: 392), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=392|message\(ANSIEscapeCode.BEL)"),
+  ("|message|", try! iTermAnnotationOptions(length: 4), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=4|message\(ANSIEscapeCode.BEL)"),
+  
+  // length: k, isHidden: true
+  // ("", try! iTermAnnotationOptions(length: 10, isHidden: true), ""),
+  
+  // x: i, y: j, length: k, isHidden: false
+  // ("", try! iTermAnnotationOptions(x: 1, y: 2, length: 10), ""),
+  // ("", try! iTermAnnotationOptions(x: 3, y: 5, length: 10, isHidden: true), ""),
+  
+  // x: i, y: j, length: k, isHidden: true
+]
+
+@Test("It should generate the correct escape code for annotations: ", arguments: testCases)
+func annotationTest(_ test: (message: String, iTermAnnotationOptions: iTermAnnotationOptions, escapeCode: String)) {
+  #expect(ANSIEscapeCode.iTerm.annotation(message: test.message, options: test.iTermAnnotationOptions) == test.escapeCode)
+}

--- a/Tests/iTerm/Annotation.swift
+++ b/Tests/iTerm/Annotation.swift
@@ -22,7 +22,10 @@ let testCases = [
   ("|message|", try! iTermAnnotationOptions(length: 4), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=4|message\(ANSIEscapeCode.BEL)"),
   
   // length: k, isHidden: true
-  // ("", try! iTermAnnotationOptions(length: 10, isHidden: true), ""),
+  ("", try! iTermAnnotationOptions(length: 3, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=3|\(ANSIEscapeCode.BEL)"),
+  ("|||||||", try! iTermAnnotationOptions(length: 42, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=42|\(ANSIEscapeCode.BEL)"),
+  ("N0ti*ciaS", try! iTermAnnotationOptions(length: 7, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=7|N0ti*ciaS\(ANSIEscapeCode.BEL)"),
+  ("|n|o|t|i|c|i|a|s", try! iTermAnnotationOptions(length: 5, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=5|noticias\(ANSIEscapeCode.BEL)"),
   
   // x: i, y: j, length: k, isHidden: false
   // ("", try! iTermAnnotationOptions(x: 1, y: 2, length: 10), ""),

--- a/Tests/iTerm/Annotation.swift
+++ b/Tests/iTerm/Annotation.swift
@@ -28,10 +28,16 @@ let testCases = [
   ("|n|o|t|i|c|i|a|s", try! iTermAnnotationOptions(length: 5, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=5|noticias\(ANSIEscapeCode.BEL)"),
   
   // x: i, y: j, length: k, isHidden: false
-  // ("", try! iTermAnnotationOptions(x: 1, y: 2, length: 10), ""),
-  // ("", try! iTermAnnotationOptions(x: 3, y: 5, length: 10, isHidden: true), ""),
+  ("", try! iTermAnnotationOptions(x: 1, y: 2, length: 3), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=|3|1|2\(ANSIEscapeCode.BEL)"),
+  ("|", try! iTermAnnotationOptions(x: 17, y: 19, length: 23), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=|23|17|19\(ANSIEscapeCode.BEL)"),
+  ("tin nhắn", try! iTermAnnotationOptions(x: 0, y: 0, length: 8), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=tin nhắn|8|0|0\(ANSIEscapeCode.BEL)"),
+  ("tin||nhắn |:)|", try! iTermAnnotationOptions(x: 1, y: 0, length: 1200), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddAnnotation=tinnhắn :)|1200|1|0\(ANSIEscapeCode.BEL)"),
   
   // x: i, y: j, length: k, isHidden: true
+  ("", try! iTermAnnotationOptions(x: 0, y: 1, length: 2, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=|2|0|1\(ANSIEscapeCode.BEL)"),
+  ("| |", try! iTermAnnotationOptions(x: 5, y: 15, length: 25, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation= |25|5|15\(ANSIEscapeCode.BEL)"),
+  ("(nachricht)", try! iTermAnnotationOptions(x: 100, y: 1000, length: 10_000, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=(nachricht)|10000|100|1000\(ANSIEscapeCode.BEL)"),
+  ("nach | richt", try! iTermAnnotationOptions(x: 64, y: 32, length: 16, isHidden: true), "\(ANSIEscapeCode.OSC)1337\(ANSIEscapeCode.SEP)AddHiddenAnnotation=nach  richt|16|64|32\(ANSIEscapeCode.BEL)"),
 ]
 
 @Test("It should generate the correct escape code for annotations: ", arguments: testCases)

--- a/Tests/iTerm/InformCurrentDir.swift
+++ b/Tests/iTerm/InformCurrentDir.swift
@@ -1,6 +1,0 @@
-import Testing
-import AnsiEscapes
-
-@Test("Informs iTerm2 of the current directory /Users") func informCurrentDir() {
-  #expect(ANSIEscapeCode.iTerm.informCurrentDir("/Users") == "\(ANSIEscapeCode.OSC)1337;CurrentDir=/Users\(ANSIEscapeCode.BEL)")
-}

--- a/Tests/iTerm/InformCurrentDir.swift
+++ b/Tests/iTerm/InformCurrentDir.swift
@@ -1,0 +1,6 @@
+import Testing
+import AnsiEscapes
+
+@Test("Informs iTerm2 of the current directory /Users") func informCurrentDir() {
+  #expect(ANSIEscapeCode.iTerm.informCurrentDir("/Users") == "\(ANSIEscapeCode.OSC)1337;CurrentDir=/Users\(ANSIEscapeCode.BEL)")
+}

--- a/Tests/iTerm/SetCurrentDir.swift
+++ b/Tests/iTerm/SetCurrentDir.swift
@@ -1,0 +1,6 @@
+import Testing
+import AnsiEscapes
+
+@Test("Informs iTerm2 of the current directory /Users") func informCurrentDir() {
+  #expect(ANSIEscapeCode.iTerm.setCurrentDir("/Users") == "\(ANSIEscapeCode.OSC)1337;CurrentDir=/Users\(ANSIEscapeCode.BEL)")
+}

--- a/Tests/iTerm/iTermAnnotationOptions.swift
+++ b/Tests/iTerm/iTermAnnotationOptions.swift
@@ -24,11 +24,11 @@ let testCasesThrowsWithIsHidden: [OptionsWithIsHidden] = [
   (494, 6, nil, false),
   (3494, 4959, nil, true),
   (nil, 92, 19, false),
-  (nil, 0, 0, true),
+  (nil, 0, 9, true),
   (33, nil, 7, false),
   (34, nil, 6, true),
   (nil, 23, 1, false),
-  (nil, 1, 0, true),
+  (nil, 1, 1, true),
 ]
 
 @Suite("If isHidden is defined") struct InitWithIsHidden {
@@ -49,12 +49,22 @@ let testCasesThrowsWithIsHidden: [OptionsWithIsHidden] = [
   @Test("it throws when x or y is defined but not all of x, y and length are defined",
         arguments: testCasesThrowsWithIsHidden)
   func initThrows(_ options: OptionsWithIsHidden) {
-    #expect(
-      throws: iTermAnnotationError.invalidOptions(
-        "`x`, `y` and `length` must be defined when `x` or `y` is defined"
-      )
-    ) {
+    #expect(throws: iTermAnnotationError.xOrYImpliesXYAndLength) {
       try iTermAnnotationOptions(x: options.x, y: options.y, length: options.length, isHidden: options.isHidden)
+    }
+  }
+  
+  @Suite("it throws when length is") struct lengthThrows {
+    @Test("0") func length0() {
+      #expect(throws: iTermAnnotationError.invalidLength) {
+        try iTermAnnotationOptions(length: 0, isHidden: false)
+      }
+    }
+    
+    @Test("negative") func lengthNegative() {
+      #expect(throws: iTermAnnotationError.invalidLength) {
+        try iTermAnnotationOptions(length: -1, isHidden: true)
+      }
     }
   }
 }
@@ -97,11 +107,22 @@ let testCasesThrowsWithoutIsHidden: [OptionsWithoutIsHidden] = [
         arguments: testCasesThrowsWithoutIsHidden)
   func initThrows(_ options: OptionsWithoutIsHidden) {
     #expect(
-      throws: iTermAnnotationError.invalidOptions(
-        "`x`, `y` and `length` must be defined when `x` or `y` is defined"
-      )
-    ) {
+      throws: iTermAnnotationError.xOrYImpliesXYAndLength) {
       try iTermAnnotationOptions(x: options.x, y: options.y, length: options.length)
+    }
+  }
+  
+  @Suite("it throws when length is") struct lengthThrows {
+    @Test("0") func length0() {
+      #expect(throws: iTermAnnotationError.invalidLength) {
+        try iTermAnnotationOptions(length: 0)
+      }
+    }
+    
+    @Test("negative") func lengthNegative() {
+      #expect(throws: iTermAnnotationError.invalidLength) {
+        try iTermAnnotationOptions(length: -1)
+      }
     }
   }
 }

--- a/Tests/iTerm/iTermAnnotationOptions.swift
+++ b/Tests/iTerm/iTermAnnotationOptions.swift
@@ -1,0 +1,107 @@
+import Testing
+@testable import AnsiEscapes
+
+let testCasesInitWithIsHidden = [
+  (nil, nil, nil, false),
+  (nil, nil, nil, true),
+  (nil, nil, 7, false),
+  (nil, nil, 2, true),
+  (2, 3, 4, false),
+  (19, 200, 2101, true),
+]
+
+typealias OptionsWithIsHidden = (x: Int?, y: Int?, length: Int?, isHidden: Bool)
+
+let testCasesThrowsWithIsHidden: [OptionsWithIsHidden] = [
+  (0, nil, nil, false),
+  (27, nil, nil, true),
+  (39, 8, nil, false),
+  (845, 29, nil, true),
+  (88, nil, 20, false),
+  (11, nil, 4, true),
+  (nil, 349, nil, false),
+  (nil, 5, nil, true),
+  (494, 6, nil, false),
+  (3494, 4959, nil, true),
+  (nil, 92, 19, false),
+  (nil, 0, 0, true),
+  (33, nil, 7, false),
+  (34, nil, 6, true),
+  (nil, 23, 1, false),
+  (nil, 1, 0, true),
+]
+
+@Suite("If isHidden is defined") struct InitWithIsHidden {
+  @Suite("it initializes the annotation options") struct InitSuccessfully {
+    @Test("", arguments: testCasesInitWithIsHidden)
+    func initWithIsHidden(_ options: OptionsWithIsHidden) {
+      #expect(throws: Never.self) {
+        try iTermAnnotationOptions(x: options.x, y: options.y, length: options.length, isHidden: options.isHidden)
+      }
+    }
+    
+    @Test("with isHidden set to the passed argument", arguments: testCasesInitWithIsHidden)
+    func isHiddenSetToArgument(_ options: OptionsWithIsHidden) {
+      #expect(try! iTermAnnotationOptions(x: options.x, y: options.y, length: options.length, isHidden: options.isHidden).isHidden == options.isHidden)
+    }
+  }
+  
+  @Test("it throws when x or y is defined but not all of x, y and length are defined",
+        arguments: testCasesThrowsWithIsHidden)
+  func initThrows(_ options: OptionsWithIsHidden) {
+    #expect(
+      throws: iTermAnnotationError.invalidOptions(
+        "`x`, `y` and `length` must be defined when `x` or `y` is defined"
+      )
+    ) {
+      try iTermAnnotationOptions(x: options.x, y: options.y, length: options.length, isHidden: options.isHidden)
+    }
+  }
+}
+
+let testCasesInitWithoutIsHidden = [
+  (nil, nil, nil),
+  (nil, nil, 4),
+  (96, 5, 6576),
+]
+
+typealias OptionsWithoutIsHidden = (x: Int?, y: Int?, length: Int?)
+
+let testCasesThrowsWithoutIsHidden: [OptionsWithoutIsHidden] = [
+  (2, nil, nil),
+  (2, 65, nil),
+  (2, nil, 49),
+  (nil, 812, nil),
+  (7, 812, nil),
+  (nil, 812, 44),
+  (0, nil, 71),
+  (nil, 1, 71),
+]
+
+@Suite("If isHidden is not defined") struct InitWithoutIsHidden {
+  @Suite("it initializes the annotation options") struct InitSuccessfully {
+    @Test("", arguments: testCasesInitWithoutIsHidden)
+    func initWithoutIsHidden(_ options: OptionsWithoutIsHidden) {
+      #expect(throws: Never.self) {
+        try iTermAnnotationOptions(x: options.x, y: options.y, length: options.length)
+      }
+    }
+    
+    @Test("with isHidden = false by default", arguments: testCasesInitWithoutIsHidden)
+    func isHiddenHasDefaultFalse(_ options: OptionsWithoutIsHidden) {
+      #expect(try! iTermAnnotationOptions(x: options.x, y: options.y, length: options.length).isHidden == false)
+    }
+  }
+  
+  @Test("it throws when x or y is defined but not all of x, y and length are defined",
+        arguments: testCasesThrowsWithoutIsHidden)
+  func initThrows(_ options: OptionsWithoutIsHidden) {
+    #expect(
+      throws: iTermAnnotationError.invalidOptions(
+        "`x`, `y` and `length` must be defined when `x` or `y` is defined"
+      )
+    ) {
+      try iTermAnnotationOptions(x: options.x, y: options.y, length: options.length)
+    }
+  }
+}


### PR DESCRIPTION
I added a namespace for iTerm2 to ANSIEscapeCode. iTerm supports many
proprietary escape codes that I want to support in the future. An own
namespace makes it more clear which escape codes work only on iTerm.

Also, I rename setCwd to setCurrentDir because it matches the name of
the escape code in the docs of iTerm2 better.

I moved iTermAnnotationOptions to its own file because I do not like
too large files because I lose the overview. Also, the annotation
options do not have to do anything with the standard ANSI escape codes.

I added a few more examples for annotations to show how they work in
iTerm2. While doing so, I found a bug when the length is not positive.
The length of the annotation has to be positive. Otherwise, it is not
displayed. I added a second error type to iTermAnnotationError. Because
invalidOptions is not very specific, I renamed it to
xOrYImpliesXYAndLength. The error messages were removed since the error
type names are already descriptive and they are difficult to handle.

Also, I added many tests and comments for iTermAnnotationOptions,
setCurrentDir and annotations.

https://iterm2.com/documentation-escape-codes.html