### PR TITLE
Remove isAppleTerminal and macros for os

### DIFF
--- a/Sources/AnsiEscapes.swift
+++ b/Sources/AnsiEscapes.swift
@@ -1,6 +1,4 @@
-func isAppleTerminal() -> Bool {
-  true
-}
+import Foundation
 
 public struct ANSIEscapeCode {
   public static let ESC = "\u{001B}["
@@ -50,23 +48,44 @@ public struct ANSIEscapeCode {
   /// Clears the terminal screen.
   public static let ClearScreen = "\u{001B}c"
   
-  public static let CursorSavePosition = isAppleTerminal() ? "\u{001B}7" : "\(ANSIEscapeCode.ESC)s"
-  public static let CursorRestorePosition = isAppleTerminal() ? "\u{001B}8" : "\(ANSIEscapeCode.ESC)u"
+  /// Saves the cursor's position.
+  /// - Parameter terminal: The terminal for which the escape code is. Defaults to the environment variable `TERM_PROGRAM`.
+  /// - Returns: The ANSI escape code.
+  public static func saveCursorPosition(inTerminal terminal: String? = ProcessInfo.processInfo.environment["TERM_PROGRAM"]) -> String {
+    if terminal == "Apple_Terminal" {
+      "\u{001B}7"
+    } else {
+      "\(ANSIEscapeCode.ESC)s"
+    }
+  }
+  
+  /// Restores the saved cursor position.
+  /// - Parameter terminal: The terminal for which the escape code is. Defaults to the environment variable `TERM_PROGRAM`.
+  /// - Returns: The ANSI escape code.
+  public static func restoreCursorPosition(inTerminal terminal: String? = ProcessInfo.processInfo.environment["TERM_PROGRAM"]) -> String {
+    if terminal == "Apple_Terminal" {
+      "\u{001B}8"
+    } else {
+      "\(ANSIEscapeCode.ESC)u"
+    }
+  }
   
   private init() {}
   
   /// Clears the whole terminal, including scrollback buffer. It does not clear just the visible part of it.
+  /// - Parameters:
+  ///   - onWindows: Whether the escape code is for Windows. Defaults to `false`.
   /// - Returns: The ANSI escape code.
-  public static func clearTerminal() -> String {
-    #if os(Windows)
-    "\(ANSIEscapeCodes.EraseScreen)\(ANSIEscapeCodes.ESC)0f"
-    #else
-    // 1. Erases the screen (Only done in case `2` is not supported)
-    // 2. Erases the whole screen including scrollback buffer
-    // 3. Moves cursor to the top-left position
-    // More info: https://www.real-world-systems.com/docs/ANSIcode.html
-    "\(ANSIEscapeCode.EraseScreen)\(ANSIEscapeCode.ESC)3J\(ANSIEscapeCode.ESC)H"
-    #endif
+  public static func clearTerminal(onWindows: Bool = false) -> String {
+    if (onWindows) {
+      "\(ANSIEscapeCode.EraseScreen)\(ANSIEscapeCode.ESC)0f"
+    } else {
+      // 1. Erases the screen (Only done in case `2` is not supported)
+      // 2. Erases the whole screen including scrollback buffer
+      // 3. Moves cursor to the top-left position
+      // More info: https://www.real-world-systems.com/docs/ANSIcode.html
+      "\(ANSIEscapeCode.EraseScreen)\(ANSIEscapeCode.ESC)3J\(ANSIEscapeCode.ESC)H"
+    }
   }
   
   /// Sets the absolute position of the cursor. `x = 0` and `y = 0` is the top left of the terminal screen. Negative integers are treated as `0`.

--- a/Tests/ClearTerminal.swift
+++ b/Tests/ClearTerminal.swift
@@ -3,20 +3,10 @@ import AnsiEscapes
 
 @Suite("Clears the terminal") struct ClearTerminal {
   @Test("on Windows") func windows() {
-    #if os(Windows)
-    #expect(ANSIEscapeCode.clearTerminal() == "\(ANSIEscapeCodes.EraseScreen)\(ANSIEscapeCodes.ESC)0f")
-    #endif
+    #expect(ANSIEscapeCode.clearTerminal(onWindows: true) == "\(ANSIEscapeCode.EraseScreen)\(ANSIEscapeCode.ESC)0f")
   }
   
-  @Test("on Linux") func linux() {
-    #if os(Linux)
+  @Test("on macOS or Linux") func macOSOrLinux() {
     #expect(ANSIEscapeCode.clearTerminal() == "\(ANSIEscapeCode.EraseScreen)\(ANSIEscapeCode.ESC)3J\(ANSIEscapeCode.ESC)H")
-    #endif
-  }
-  
-  @Test("on macOS") func macOS() {
-    #if os(macOS)
-    #expect(ANSIEscapeCode.clearTerminal() == "\(ANSIEscapeCode.EraseScreen)\(ANSIEscapeCode.ESC)3J\(ANSIEscapeCode.ESC)H")
-    #endif
   }
 }

--- a/Tests/RestoreCursorPosition.swift
+++ b/Tests/RestoreCursorPosition.swift
@@ -1,0 +1,12 @@
+import Testing
+import AnsiEscapes
+
+@Suite("Restores the saved cursor position") struct RestoreCursorPosition {
+  @Test("in Apple's Terminal") func inAppleTerminal() {
+    #expect(ANSIEscapeCode.restoreCursorPosition(inTerminal: "Apple_Terminal") == "\u{001B}8")
+  }
+    
+  @Test("in other terminals") func otherTerminals() {
+    #expect(ANSIEscapeCode.restoreCursorPosition(inTerminal: "iTerm2") == "\(ANSIEscapeCode.ESC)u")
+  }
+}

--- a/Tests/SaveCursorPosition.swift
+++ b/Tests/SaveCursorPosition.swift
@@ -1,0 +1,12 @@
+import Testing
+import AnsiEscapes
+
+@Suite("Saves the cursor's position") struct SaveCursorPosition {
+  @Test("in Apple's Terminal") func inAppleTerminal() {
+    #expect(ANSIEscapeCode.saveCursorPosition(inTerminal: "Apple_Terminal") == "\u{001B}7")
+  }
+    
+  @Test("in other terminals") func otherTerminals() {
+    #expect(ANSIEscapeCode.saveCursorPosition(inTerminal: "iTerm2") == "\(ANSIEscapeCode.ESC)s")
+  }
+}


### PR DESCRIPTION
I removed the macros that make code only available on specific OSes. swift-dotenv uses Foundations' ProcessInfo.processInfo.environment on Linux [0]. Additionally, this makes it possible to generate ANSI escape codes for Windows while being on macOS, for example.

By setting the default value of terminal as the environment variable TERM_PROGRAM, it is possible to test the method without having to mock ProcessInfo.

[0]: https://github.com/thebarndog/swift-dotenv/tree/HEAD@{2025-03-26T18:10:27Z}/Sources/Dotenv.swift